### PR TITLE
Fix for issue #276 Added a checks to prevent booking completed rides.

### DIFF
--- a/project/carpool/models/ride.py
+++ b/project/carpool/models/ride.py
@@ -33,7 +33,7 @@ class RideManager(models.Manager):
 
     def safe_delete(self, ride) -> bool:
         """Soft delete rides delete the ride only if has no riders or if the ride has ended."""
-        if ride.rider.count() == 0 or (ride.end_dt and ride.end_dt < timezone.now()):
+        if ride.rider.count() == 0 or ride.has_ended:
             ride.delete()
             return True
         return False
@@ -181,6 +181,10 @@ class Ride(models.Model):
     )
 
     objects = RideManager()
+
+    @property
+    def has_ended(self):
+        return self.end_dt and self.end_dt < timezone.now()
 
     @property
     def remaining_seats(self):

--- a/project/carpool/templates/rides/detail.html
+++ b/project/carpool/templates/rides/detail.html
@@ -173,7 +173,9 @@
                 </div>
             </div>
             {% if not ride.driver == user %}
-            {% if not chat_request %}
+            {% if ride.has_ended %}
+                <p class="alert alert-warning">Ride has been completed.</p>
+            {% elif not chat_request %}
             <form action="{% url 'carpool:chat' ride.pk %}" method="post">
                 {% csrf_token %}
                 <button class="btn btn-primary w-100" type="submit">{% translate "Start a discussion" %}</button>

--- a/project/carpool/views/__init__.py
+++ b/project/carpool/views/__init__.py
@@ -150,6 +150,9 @@ def rides_subscribe(request, ride_pk):
     """Create a reservation for the given ride."""
     ride = get_object_or_404(Ride, pk=ride_pk)
     if request.method == "POST":
+        if ride.has_ended():
+            messages.error(request, "You cannot book a completed ride.")
+            return redirect("carpool:list")
         # Get the chat request
         ChatRequest.objects.get(user=request.user, ride=ride)
 


### PR DESCRIPTION
**Summary**
Prevent booking and start of a chat of a completed ride (fix for #276 )

**Changes**
- Added has_ended property to the Ride model for easier check
- Check for ride completion before subscription to a ride
- Remove the "Start discussion" button in the ride detail page and show a warning message instead if the ride has ended


This is my first time contributing, please say if I did anything wrong :)