### PR TITLE
Fix #372 : error message when no vehicle is registered

### DIFF
--- a/project/carpool/locale/fr/LC_MESSAGES/django.po
+++ b/project/carpool/locale/fr/LC_MESSAGES/django.po
@@ -880,6 +880,10 @@ msgstr ""
 "Vous ne pouvez pas supprimer ce trajet car il a des passagers et n'est pas "
 "encore terminé."
 
+#: carpool/views/rides.py:67
+msgid "You must choose a vehicle."
+msgstr "Vous devez choisir un véhicule."
+
 #: carpool/views/rides.py:129
 msgid "You successfully updated the ride."
 msgstr "Vous avez mis à jour le trajet avec succès."

--- a/project/carpool/views/rides.py
+++ b/project/carpool/views/rides.py
@@ -10,7 +10,7 @@ from django.contrib import messages
 from django.utils.translation import gettext as _
 
 from carpool.forms.ride import CreateRideStep1Form, CreateRideStep2Form, EditRideForm
-from carpool.models import Step
+from carpool.models import Step, Vehicle
 from carpool.models.ride import Ride
 from carpool.utils import get_or_create_location
 
@@ -62,6 +62,8 @@ def create_step2(request):
     form = CreateRideStep2Form()
     if request.method == "POST":
         form = CreateRideStep2Form(request.POST)
+        if Vehicle.objects.get_queryset().count() == 0:
+            messages.error(request, _("You must choose a vehicle."))
         if form.is_valid():
             # Create or get locations
             d_data = step1_data.pop("departure")


### PR DESCRIPTION
When publishing a route, if no vehicle is registred, an error message will appear.